### PR TITLE
Add GitHub buttons just below the heading.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,12 @@
 <body>
 	<h1>Preston Hunter<span class="very_light">:</span>
 	<br> &nbsp; world-class <span class="strongest">database designer</span> and <span class="stronger">programmer</span></h1>
+
+	<!-- Place this tag where you want the button to render. -->
+	<a class="github-button" href="https://github.com/prestonhunter" data-size="large" data-show-count="true" aria-label="Follow @prestonhunter on GitHub">Follow @prestonhunter</a>
+	<!-- Place this tag where you want the button to render. -->
+	<a class="github-button" href="https://github.com/Database-Genius/Database-Genius.github.io" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star Database-Genius/Database-Genius.github.io on GitHub">Star</a>
+
 	<p>If you are trying to contact Preston Hunter because you need a world-class database designer and programmer... Then you have come to the right place.</p>
 
 	<aside>The <span class="strongest">data</span> is the thing.</aside>
@@ -139,5 +145,8 @@
 
 <span id="genius">Database-Genius.com</span>
 <br><a href="https://database-genius.com:2087/">staff login</a>
+
+<!-- Place this tag in your head or just before your close body tag. -->
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 
 </body></html>


### PR DESCRIPTION
This pull request adds two GitHub buttons just below the website heading.  The two buttons are 'Follow Preston Hunter on GitHub' and 'Star the Database-Genius.github.io website'

The buttons just link to Github where you then can star or follow if you are logged it.

You can read up on the library I am using here -> https://github.com/ntkme/github-buttons

And you can see where the HTML code that is generated for the buttons here -> https://buttons.github.io/

